### PR TITLE
Add prototype automation agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# AI Automation Agent
+
+This repository contains a prototype automation script that demonstrates how to
+collect trending Reddit posts and transform them into short videos for posting on
+TikTok, YouTube Shorts and Instagram Reels. The implementation uses placeholder
+logic for API integrations and is intended to be imported into n8n for further
+workflow automation.
+
+## Features
+
+1. **Trend Research Module**
+   - Fetches top posts from target subreddits.
+   - Placeholder function for cross‑referencing Google Trends.
+2. **Content Transformation Engine**
+   - Generates three script variants per post (serious, humorous, dramatic).
+3. **Video Production System**
+   - Mocks calls to Fliki API for video generation.
+4. **Posting Automation**
+   - Demonstrates scheduling posts with hashtags.
+5. **Monetization & Anti-Saturation**
+   - Simple logic to determine sponsorship eligibility and avoid duplicate content.
+
+## Usage
+
+```bash
+python automation_agent.py
+```
+
+The script prints mock actions to the console. To build a complete system, replace
+the placeholder sections with real API calls and import the logic into n8n.

--- a/automation_agent.py
+++ b/automation_agent.py
@@ -1,0 +1,157 @@
+"""
+AI Automation Agent
+
+This script outlines an automation pipeline for generating social media videos
+from trending Reddit content. It demonstrates how to combine multiple APIs
+(Reddit, Google Trends, Fliki, TikTok) using placeholder logic that can be
+extended with real API calls. The project can be imported into n8n using the
+included JSON workflow file.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from typing import List, Dict, Any
+
+# ----------------------------- Trend Research ------------------------------
+
+@dataclasses.dataclass
+class RedditPost:
+    subreddit: str
+    title: str
+    score: int
+    num_comments: int
+    url: str
+
+
+def fetch_trending_reddit_posts(subreddits: List[str]) -> List[RedditPost]:
+    """Fetch top posts from specified subreddits using Reddit API."""
+    # Placeholder for actual Reddit API calls
+    posts = []
+    for name in subreddits:
+        # simulate one post per subreddit
+        posts.append(
+            RedditPost(
+                subreddit=name,
+                title=f"Example post from {name}",
+                score=1234,
+                num_comments=56,
+                url=f"https://reddit.com/r/{name}/example",
+            )
+        )
+    return posts
+
+
+def cross_reference_google_trends(keyword: str) -> float:
+    """Return Google Trends score for a keyword (0-100)."""
+    # Placeholder for real Google Trends API
+    return 50.0
+
+
+# -------------------------- Content Transformation -------------------------
+
+@dataclasses.dataclass
+class ScriptVariant:
+    tone: str
+    text: str
+
+
+def generate_scripts(post: RedditPost) -> List[ScriptVariant]:
+    """Generate video script variants for a Reddit post."""
+    tones = ["serious", "humorous", "dramatic"]
+    variants = []
+    for tone in tones:
+        hook = "Would you do this?" if tone == "dramatic" else "This changed everything"
+        body = post.title  # placeholder for full story
+        cta = "Comment your take" if tone != "humorous" else "Tag someone who needs this"
+        script = f"{hook}\n{body}\n{cta}"
+        variants.append(ScriptVariant(tone=tone, text=script))
+    return variants
+
+
+# -------------------------- Video Production -------------------------------
+
+@dataclasses.dataclass
+class VideoSpec:
+    script: ScriptVariant
+    filename: str
+
+
+def create_video(spec: VideoSpec) -> str:
+    """Use Fliki API to generate a video from a script."""
+    # Placeholder for real Fliki API integration
+    output_file = f"videos/{spec.filename}.mp4"
+    print(f"[mock] Generating video {output_file} with tone '{spec.script.tone}'")
+    return output_file
+
+
+# -------------------------- Posting Automation -----------------------------
+
+def schedule_post(video_path: str, caption: str, platform: str, when: datetime.datetime) -> None:
+    """Schedule a post on TikTok, YouTube Shorts, or Instagram Reels."""
+    print(f"[mock] Scheduling {platform} post for {when.isoformat()} -> {video_path}")
+
+
+def generate_hashtags(trending: List[str]) -> List[str]:
+    """Return a list of hashtags for the post."""
+    base_tags = ["#MindsetMonday", "#MotivationMachine"]
+    return trending[:3] + base_tags
+
+
+# -------------------------- Monetization -----------------------------------
+
+def analyze_views_for_sponsorship(views: int) -> bool:
+    return views >= 10_000
+
+
+# -------------------------- Anti-Saturation --------------------------------
+
+_previous_titles: List[str] = []
+
+
+def is_unique(post: RedditPost) -> bool:
+    """Check if the post is sufficiently different from prior content."""
+    global _previous_titles
+    similarity = sum(1 for t in _previous_titles if t == post.title)
+    unique = similarity == 0
+    if unique:
+        _previous_titles.append(post.title)
+    return unique
+
+
+# -------------------------- Pipeline Runner --------------------------------
+
+SUBREDDITS = [
+    "GetMotivated",
+    "AmItheAsshole",
+    "TIFU",
+    "AskReddit",
+    "UpliftingNews",
+]
+
+
+def run_daily_workflow() -> None:
+    posts = fetch_trending_reddit_posts(SUBREDDITS)
+    for post in posts:
+        if not is_unique(post):
+            print(f"Skipping similar content: {post.title}")
+            continue
+        trends_score = cross_reference_google_trends(post.title)
+        scripts = generate_scripts(post)
+        for variant in scripts:
+            spec = VideoSpec(script=variant, filename=f"{post.subreddit}_{variant.tone}")
+            video = create_video(spec)
+            caption = f"{post.title} | Score: {trends_score}"
+            hashtags = generate_hashtags(["#trending1", "#trending2", "#trending3"])
+            full_caption = caption + " " + " ".join(hashtags)
+            schedule_post(
+                video_path=video,
+                caption=full_caption,
+                platform="TikTok",
+                when=datetime.datetime.utcnow(),
+            )
+
+
+if __name__ == "__main__":
+    run_daily_workflow()

--- a/workflow.json
+++ b/workflow.json
@@ -1,0 +1,44 @@
+{
+  "name": "Reddit Video Automation",
+  "nodes": [
+    {
+      "parameters": {
+        "url": "https://www.reddit.com/r/GetMotivated.json"
+      },
+      "id": 1,
+      "name": "Fetch Reddit",
+      "type": "httpRequest",
+      "typeVersion": 1,
+      "position": [
+        200,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "return items;"
+      },
+      "id": 2,
+      "name": "Transform",
+      "type": "function",
+      "typeVersion": 1,
+      "position": [
+        400,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Fetch Reddit": {
+      "main": [
+        [
+          {
+            "node": "Transform",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `automation_agent.py` with modules for trending research, content transformation, video production and posting
- add an n8n workflow example
- document how to run the script

## Testing
- `python3 automation_agent.py | head -n 5`
- `python3 -m py_compile automation_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_685735915a5883339128eaa7d3094317